### PR TITLE
fix-issue

### DIFF
--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -1,4 +1,4 @@
-process.env.NODE_ENV = process.env.NODE_ENV || 'production'
+process.env.NODE_ENV = 'production'
 
 const environment = require('./environment')
 


### PR DESCRIPTION
Fix issue in webpack build.
The code below will always not have a production value for the variable `process.env.NODE_ENV` has an existing value
`process.env.NODE_ENV = process.env.NODE_ENV || 'production'`